### PR TITLE
Fixed scope of unused_port_factory fixture

### DIFF
--- a/pytest_mockservers/http_server.py
+++ b/pytest_mockservers/http_server.py
@@ -63,7 +63,7 @@ def unused_port():
     _unused_port()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def unused_port_factory():
     produced = set()
 


### PR DESCRIPTION
Changed scope of unused_port_factory to "session" in order to persist the set of used ports between tests