### PR TITLE
Use the same address for checking port availability and starting server

### DIFF
--- a/pytest_mockservers/http_server.py
+++ b/pytest_mockservers/http_server.py
@@ -81,7 +81,7 @@ def unused_port_factory():
 
 @pytest.fixture
 def http_server(unused_port_factory) -> Server:
-    return Server(host="0.0.0.0", port=unused_port_factory())
+    return Server(host="127.0.0.1", port=unused_port_factory())
 
 
 @pytest.fixture


### PR DESCRIPTION
Fix `OSError` when the port is available for address 127.0.0.1 but is not available for 0.0.0.0.