### PR TITLE
Added _protocol_instance protected attribute to UDPServer.

### DIFF
--- a/pytest_mockservers/udp_server.py
+++ b/pytest_mockservers/udp_server.py
@@ -15,7 +15,7 @@ class DefaultProtocol(DatagramProtocol):
 
 
 class UDPServer:
-    __slots__ = ("_host", "_port", "_loop", "_protocol", "_transport")
+    __slots__ = ("_host", "_port", "_loop", "_protocol", "_transport", "_protocol_instance")
 
     def __init__(
         self,
@@ -30,13 +30,14 @@ class UDPServer:
 
         self._loop = loop or asyncio.get_event_loop()
         self._protocol = protocol or DefaultProtocol
+        self._protocol_instance = None
         self._transport = None
 
     async def __aenter__(self):
         listen = self._loop.create_datagram_endpoint(
             self._protocol, local_addr=(self._host, self._port)
         )
-        self._transport, _ = await listen
+        self._transport, self._protocol_instance = await listen
 
     async def __aexit__(self, exc_type, exc, tb):
         self._transport.close()


### PR DESCRIPTION
This may require further tweaking.

`create_datagram_endpoint` returns a tuple of transport and protocol instance. The latter was previously ignored and `self._protocol` allowed access only to the protocol class/constructor.

What this change does is that it allows keeping the state of the protocol in the server class and accessing that state after the test was performed.

This allows you to write your ServerProtocol class outside of the test and reuse that class between the tests, without relying on closures to store the number of calls, as it is currently done.

```python
udp_server = UDPServer(
    host='127.0.0.1', port=unused_udp_port, protocol=lambda: MyServerProtocol(planned_responses)
)

async with udp_server:
    await GameClient('127.0.0.1', unused_udp_port).get()

assert len(udp_server._protocol_instance.requests_received) == 3
```

I'd be willing to rewrite the tests to make use of _protocol_instance, if you want. Or not, if you want to keep them as they are.