### PR TITLE
Allow protocol to be callable

### DIFF
--- a/pytest_mockservers/udp_server.py
+++ b/pytest_mockservers/udp_server.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import socket
 from asyncio import AbstractEventLoop, DatagramProtocol
-from typing import Callable, Optional, Type
+from typing import Callable, Optional, Type, Union
 
 import pytest
 
@@ -23,7 +23,7 @@ class UDPServer:
         host: str,
         port: int,
         loop: Optional[AbstractEventLoop] = None,
-        protocol: Optional[Type[DatagramProtocol]] = None,
+        protocol: Optional[Type[Union[DatagramProtocol, Callable]]] = None,
     ) -> None:
         self._host = host
         self._port = port


### PR DESCRIPTION
Feel free to reject this if you don't like this change.

Basically, instead of passing a class to UDPServer, that will be created using the default constructor, like this:
```python
udp_server = UDPServer(
        host='127.0.0.1', port=unused_udp_port, protocol=ServerProtocol
    )
```

you can pass in a lambda that returns a constructed ServerProtocol, like that:

```python
udp_server = UDPServer(
        host='127.0.0.1', port=unused_udp_port, protocol=lambda: ServerProtocol(planned_responses)
    )
```

This allows you for additional customization of the ServerProtocol instance allowing for better code reuse across several tests. However, linters then complain that the lambda that is passed in is not of `DatagramProtocol` type.